### PR TITLE
Add documentation for CastError in Mongoose (ObjectId)

### DIFF
--- a/errors/expressjs/cast-error-objectid-mongoose/README.md
+++ b/errors/expressjs/cast-error-objectid-mongoose/README.md
@@ -1,0 +1,162 @@
+Perfect, Shafiq! Below is a **single `.md` file**, properly structured and formatted. You can copy everything below and **paste it directly into your `README.md`** file — no editing needed.
+
+---
+
+```md
+# CastError: Cast to ObjectId failed
+
+<!-- Example: CastError: Cast to ObjectId failed for value "abc123" at path "_id" for model "Product" -->
+
+---
+
+## Error Message
+
+```
+
+CastError: Cast to ObjectId failed for value "abc123" at path "\_id" for model "Product"
+
+````
+
+---
+
+## Context
+
+- **Where does this error occur?**  
+  This error occurs in the backend of MERN stack applications, specifically when using Mongoose with MongoDB and Express.js.
+
+- **When does it typically happen?**  
+  It usually happens when an invalid or incorrectly formatted ID (e.g., a plain string instead of a MongoDB ObjectId) is passed in the route or query — such as `/products/abc123`.
+
+---
+
+## Problem
+
+MongoDB (via Mongoose) expects certain fields — like `_id` — to be valid `ObjectId`s. If a malformed or invalid value is passed (e.g., `"abc123"` instead of a 24-character hex ID), Mongoose throws a `CastError`.
+
+---
+
+## Solution(s)
+
+### 1. Validate and Handle the ID in Express.js
+
+**Steps:**
+1. Use validation middleware (`express-validator`) to ensure inputs are valid before querying the database.
+2. Catch `CastError` and return a user-friendly message.
+
+```js
+const { body, validationResult } = require('express-validator');
+const Product = require('./models/Product');
+
+app.put('/products/:id', [
+  body('price').isNumeric().withMessage('Price must be a number'),
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+
+  try {
+    const updatedProduct = await Product.findByIdAndUpdate(
+      req.params.id,
+      { price: req.body.price },
+      { new: true }
+    );
+    if (!updatedProduct) {
+      return res.status(404).json({ message: 'Product not found' });
+    }
+    res.json(updatedProduct);
+  } catch (error) {
+    if (error.name === 'CastError') {
+      return res.status(400).json({ error: 'Invalid Product ID format' });
+    }
+    res.status(500).json({ message: 'Server Error' });
+  }
+});
+````
+
+---
+
+### 2. Ensure Valid Input from React Frontend
+
+**Steps:**
+
+1. Convert string values to the expected types (e.g., number).
+2. Handle error messages returned from the backend.
+
+```js
+const handleSubmit = async (e) => {
+  e.preventDefault();
+  try {
+    const response = await fetch(`/products/${product._id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ price: parseFloat(price) }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      setError(data.error || 'Something went wrong');
+    }
+  } catch (err) {
+    setError(err.message);
+  }
+};
+```
+
+---
+
+## Example
+
+<details>
+<summary>Show Example</summary>
+
+**Express Route**
+
+```js
+app.get('/products/:id', async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id);
+    res.json(product);
+  } catch (error) {
+    if (error.name === 'CastError') {
+      res.status(400).json({ error: 'Invalid Product ID' });
+    }
+  }
+});
+```
+
+**React Call**
+
+```js
+await fetch(`/products/${id}`);
+```
+
+</details>
+
+---
+
+## References
+
+* [Mongoose Error Handling](https://mongoosejs.com/docs/middleware.html#error-handling)
+* [express-validator Docs](https://express-validator.github.io/docs/)
+* [MongoDB ObjectId Docs](https://www.mongodb.com/docs/manual/reference/method/ObjectId/)
+
+---
+
+## Version
+
+* **Solution version:** 1.0.0
+* **Last updated:** 2025-06-22
+* **Contributed by:** [@shafiq079](https://github.com/shafiq079)
+
+---
+
+## Tags
+
+`#mongodb` `#mongoose` `#express` `#react` `#error` `#castError` `#objectId`
+
+```
+
+
+


### PR DESCRIPTION
```
This PR adds documentation for resolving the "CastError: Cast to ObjectId failed" error in MERN stack applications using Mongoose.

It includes:
- Explanation of the error and when it occurs
- Backend solution using express-validator and proper error handling
- Frontend example showing how to handle input and display error messages
- Minimal working example for reference
- Helpful external documentation links

File added: `errors/expressjs/cast-error-objectid-mongoose/README.md`

Contributed by: @shafiq079
```
